### PR TITLE
Fix: Ensure assessment answers are cleared for new assessments

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -44,6 +44,8 @@ class AIProjectAssessmentApp {
     // Start assessment button
     const startBtn = document.querySelector(DOM_SELECTORS.wizard.startBtn);
     startBtn?.addEventListener('click', () => {
+      // Ensure editingId is cleared when starting a fresh assessment from the main button
+      stateManager.setState('editingId', null);
       this.wizardController.startAssessment();
     });
 

--- a/js/managers/navigation-manager.js
+++ b/js/managers/navigation-manager.js
@@ -3,6 +3,7 @@
  */
 import { DOM_SELECTORS } from '../config/dom-selectors.js';
 import { CONSTANTS } from '../config/constants.js';
+import { stateManager } from './state-manager.js';
 
 export class NavigationManager {
   constructor() {
@@ -38,6 +39,8 @@ export class NavigationManager {
 
         // NEW LOGIC: If clicking "New Assessment", reset the state first
         if (page === 'assessment' && this.wizardController) {
+          // Clear editingId before starting over to ensure a fresh assessment
+          stateManager.setState('editingId', null);
           this.wizardController.startOver();
         }
         


### PR DESCRIPTION
Previously, if a user started editing a previous assessment and then navigated to start a new assessment (either via the 'New Assessment' link or by going back to the main start page and clicking the 'Start New Assessment' button), the answers from the edited assessment would incorrectly pre-fill the new assessment.

This was because the `editingId` in the `stateManager` was not being cleared before the `resetAssessment` logic was called. The `resetAssessment` function intentionally preserves answers if `editingId` is set, to support the edit workflow.

This commit addresses the issue by:
1. Modifying `navigation-manager.js`: When the 'New Assessment' navigation link is clicked, `editingId` is explicitly set to `null` before `wizardController.startOver()` (which calls `resetAssessment`) is invoked.
2. Modifying `main.js`: When the main 'Start New Assessment' button (on the initial wizard screen) is clicked, `editingId` is explicitly set to `null` before `wizardController.startAssessment()` (which also calls `resetAssessment`) is invoked.

These changes ensure that when a user intends to start a truly new assessment, the state is correctly reset, providing a blank form.